### PR TITLE
Cope with digest-only images

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,16 @@ func main() {
 		logger.Fatal(err)
 	}
 	for _, img := range images {
-		nameParts := strings.Split(img.RepoTags[0], ":")
+		var nameParts []string
+		// If you pull an image via digest (`docker pull ubuntu@sha256:$FULL_SHA`)
+		// we might not have a tag, just a digest.
+		if len(img.RepoTags) > 0 {
+			nameParts = strings.Split(img.RepoTags[0], ":")
+		} else if len(img.RepoDigests) > 0 {
+			nameParts = strings.Split(img.RepoDigests[0], "@")
+		} else {
+			continue
+		}
 		ii := LocalImage{ID: img.ID, Name: nameParts[0], Tag: nameParts[1], CreatedAt: time.Unix(img.Created, 0)}
 		LocalImages[nameParts[0]] = append(LocalImages[nameParts[0]], ii)
 	}


### PR DESCRIPTION
Since docker 1.10 it is possible to pull a docker image by a "content-addressable hash":

`docker pull ubuntu@sha256:6b09109fc65866361139420c5582c6c41276731a877c1fb359ef3457286973ca`

If you have only pulled an image via a digest then this would fail because `img.RepoTags` would be a zero-length slice. If that's the case then get the name out out RepoDigests  instead.